### PR TITLE
Push docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ services:
 
 script:
     - ./test-build.sh janusgraph-server
+
+after_success:
+    - if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+      docker push yihongwang/janusgraph-server;
+      fi

--- a/test-build.sh
+++ b/test-build.sh
@@ -3,4 +3,4 @@
 variant="$1"
 
 version=$(grep "$variant" version | sed -E 's/'"$variant"'\s*//')
-docker build -t janusgraph:"$variant" --build-arg COMMIT="$version" "$variant"
+docker build -t yihongwang/"$variant" --build-arg COMMIT="$version" "$variant"


### PR DESCRIPTION
When the build of master branch passes, automatically publish
docker image for janusgraph-server

Need to figure out a way to support multiple variants in the
future.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>