### PR TITLE
Add janusgraph-console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,15 @@ services:
 
 script:
     - ./test-build.sh janusgraph-server
+    - ./test-build.sh janusgraph-console
 
 after_success:
     - if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" == "false" ]; then
       docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-      docker push yihongwang/janusgraph-server;
+      docker tag janusgraph $DOCKER_ORG/janusgraph;
+      docker push $DOCKER_ORG/janusgraph;
+      docker tag janusgraph-server $DOCKER_ORG/janusgraph-server;
+      docker push $DOCKER_ORG/janusgraph-server;
+      docker tag janusgraph-console $DOCKER_ORG/janusgraph-console;
+      docker push $DOCKER_ORG/janusgraph-console;
       fi

--- a/janusgraph-console/Dockerfile
+++ b/janusgraph-console/Dockerfile
@@ -1,0 +1,9 @@
+FROM janusgraph
+
+WORKDIR /home/janusgraph/janusgraph
+
+RUN set -x && mkdir files
+
+VOLUME /home/janusgraph/janusgraph/files
+
+CMD [ "/home/janusgraph/janusgraph/bin/gremlin.sh" ]

--- a/janusgraph-server/Dockerfile
+++ b/janusgraph-server/Dockerfile
@@ -1,50 +1,10 @@
-FROM openjdk:8-jdk
-
-ARG COMMIT
-
-ENV COMMIT $COMMIT
-
-RUN groupadd --gid 1000 janusgraph \
-  && useradd --uid 1000 --gid janusgraph --shell /bin/bash --create-home janusgraph
-
-RUN buildDeps='ant junit junit4 libaopalliance-java libapache-pom-java libasm-java \
-  libatinject-jsr330-api-java libbsh-java libcdi-api-java libcglib-java \
-  libclassworlds-java libcommons-cli-java libcommons-codec-java libcommons-httpclient-java \
-  libcommons-io-java libcommons-lang-java libcommons-lang3-java libcommons-logging-java \
-  libcommons-net-java libcommons-parent-java libdoxia-core-java libeasymock-java \
-  libeclipse-aether-java libgeronimo-interceptor-3.0-spec-java libguava-java \
-  libguice-java libhamcrest-java libhttpclient-java libhttpcore-java libjaxen-java \
-  libjaxp1.3-java libjdom1-java libjetty9-java libjsch-java libjsoup-java \
-  libjsr305-java libjzlib-java liblog4j1.2-java libmaven-parent-java libmaven2-core-java \
-  libmaven3-core-java libobjenesis-java libplexus-ant-factory-java libplexus-archiver-java \
-  libplexus-bsh-factory-java libplexus-cipher-java libplexus-classworlds-java \
-  libplexus-classworlds2-java libplexus-cli-java libplexus-component-annotations-java \
-  libplexus-component-metadata-java libplexus-container-default-java libplexus-container-default1.5-java \
-  libplexus-containers-java libplexus-containers1.5-java libplexus-interactivity-api-java \
-  libplexus-interpolation-java libplexus-io-java libplexus-sec-dispatcher-java \
-  libplexus-utils-java libplexus-utils2-java libqdox2-java libservlet3.1-java libsisu-inject-java \
-  libsisu-plexus-java libslf4j-java libwagon-java libwagon2-java libxalan2-java \
-  libxbean-java libxerces2-java libxml-commons-external-java libxml-commons-resolver1.1-java \
-  maven' \
-  && set -x \
-  && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/* \
-  && cd /home/janusgraph \
-  && git clone https://github.com/JanusGraph/janusgraph.git \
-  && cd janusgraph \
-  && git checkout $COMMIT \
-  && mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-     -T $(getconf _NPROCESSORS_ONLN) clean install -DskipTests=true \
-  && sed -E -i.bak 's/storage\.hostname=.*$/storage\.hostname=cassandra-server/' conf/gremlin-server/janusgraph-cassandra-es-server.properties \
-  && sed -E -i.bak 's/index\.search\.hostname=.*$/index\.search\.hostname=es-server/' conf/gremlin-server/janusgraph-cassandra-es-server.properties \
-  && rm conf/gremlin-server/janusgraph-cassandra-es-server.properties.bak \
-  && rm -rf /root/.m2/ /home/janusgraph/janusgraph/janusgraph* \
-  && chown janusgraph:janusgraph -R /home/janusgraph/janusgraph \
-  && apt-get purge -y --auto-remove $buildDeps
+FROM janusgraph
 
 WORKDIR /home/janusgraph/janusgraph
 
 RUN set -x \
+  && sed -E -i.bak 's/storage\.hostname=.*$/storage\.hostname=cassandra-server/' conf/gremlin-server/janusgraph-cassandra-es-server.properties \
+  && sed -E -i.bak 's/index\.search\.hostname=.*$/index\.search\.hostname=es-server/' conf/gremlin-server/janusgraph-cassandra-es-server.properties \
   && sed -E -i.bak 's/channel\.WebSocketChannelizer/channel\.HttpChannelizer/' conf/gremlin-server/gremlin-server.yaml \
   && rm conf/gremlin-server/gremlin-server.yaml.bak
 

--- a/janusgraph/Dockerfile
+++ b/janusgraph/Dockerfile
@@ -1,0 +1,44 @@
+FROM openjdk:8-jdk
+
+ARG COMMIT
+
+ENV COMMIT $COMMIT
+
+RUN groupadd --gid 1000 janusgraph \
+  && useradd --uid 1000 --gid janusgraph --shell /bin/bash --create-home janusgraph
+
+RUN buildDeps='ant junit junit4 libaopalliance-java libapache-pom-java libasm-java \
+  libatinject-jsr330-api-java libbsh-java libcdi-api-java libcglib-java \
+  libclassworlds-java libcommons-cli-java libcommons-codec-java libcommons-httpclient-java \
+  libcommons-io-java libcommons-lang-java libcommons-lang3-java libcommons-logging-java \
+  libcommons-net-java libcommons-parent-java libdoxia-core-java libeasymock-java \
+  libeclipse-aether-java libgeronimo-interceptor-3.0-spec-java libguava-java \
+  libguice-java libhamcrest-java libhttpclient-java libhttpcore-java libjaxen-java \
+  libjaxp1.3-java libjdom1-java libjetty9-java libjsch-java libjsoup-java \
+  libjsr305-java libjzlib-java liblog4j1.2-java libmaven-parent-java libmaven2-core-java \
+  libmaven3-core-java libobjenesis-java libplexus-ant-factory-java libplexus-archiver-java \
+  libplexus-bsh-factory-java libplexus-cipher-java libplexus-classworlds-java \
+  libplexus-classworlds2-java libplexus-cli-java libplexus-component-annotations-java \
+  libplexus-component-metadata-java libplexus-container-default-java libplexus-container-default1.5-java \
+  libplexus-containers-java libplexus-containers1.5-java libplexus-interactivity-api-java \
+  libplexus-interpolation-java libplexus-io-java libplexus-sec-dispatcher-java \
+  libplexus-utils-java libplexus-utils2-java libqdox2-java libservlet3.1-java libsisu-inject-java \
+  libsisu-plexus-java libslf4j-java libwagon-java libwagon2-java libxalan2-java \
+  libxbean-java libxerces2-java libxml-commons-external-java libxml-commons-resolver1.1-java \
+  maven' \
+  && set -x \
+  && apt-get update && apt-get install -y $buildDeps --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/* \
+  && cd /home/janusgraph \
+  && git clone https://github.com/JanusGraph/janusgraph.git \
+  && cd janusgraph \
+  && git checkout $COMMIT \
+  && mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+     -T $(getconf _NPROCESSORS_ONLN) clean install -DskipTests=true \
+  && rm -rf /root/.m2/ /home/janusgraph/janusgraph/janusgraph* \
+  && chown janusgraph:janusgraph -R /home/janusgraph/janusgraph \
+  && apt-get purge -y --auto-remove $buildDeps
+
+WORKDIR /home/janusgraph/janusgraph
+
+CMD [ "/bin/bash" ]

--- a/test-build.sh
+++ b/test-build.sh
@@ -2,5 +2,10 @@
 
 variant="$1"
 
-version=$(grep "$variant" version | sed -E 's/'"$variant"'\s*//')
-docker build -t yihongwang/"$variant" --build-arg COMMIT="$version" "$variant"
+# Make sure the base is already there
+version=$(grep "janusgraph" version | sed -E 's/janusgraph\s*//')
+docker build -t janusgraph --build-arg COMMIT="$version" janusgraph
+
+if [ "$variant" != "" ]; then
+  docker build -t "$variant" "$variant"
+fi

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-janusgraph-server dbbda285af0b3752b75178aa4dd62516200c50d5
+janusgraph dbbda285af0b3752b75178aa4dd62516200c50d5


### PR DESCRIPTION
This docker image is used to run gremlin-console. The
`/home/janusgraph/janusgraph/files` could be mounted from the host
and use `files/` inside gremlin-console to access the files.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>